### PR TITLE
Return download job status as PENDING on initial request

### DIFF
--- a/btsapi/modules/reports/controllers.py
+++ b/btsapi/modules/reports/controllers.py
@@ -190,8 +190,8 @@ def download_report(report_id):
                               body=data)
         channel.close()
 
-        return jsonify({'status': 'success',
-                        'message': 'Download request received.',
+        return jsonify({'status': 'PENDING', # Job status
+                        'message': 'Download job logged.',
                         'status_url': '/api/reports/download/status/{}'.format(task_id),
                         'download_url': '/api/reports/file/{}'.format(task_id)} )
     except Exception as e:


### PR DESCRIPTION
When a request to /api/reports/download/<report_id> is made initially,
the status field will be set to PENDING